### PR TITLE
Tweak block indicator styling

### DIFF
--- a/content.js
+++ b/content.js
@@ -16,8 +16,8 @@ function injectStyles() {
             position: relative;
         }
         .detective-wapuu-overlay {
-            background-color: rgba(251, 93, 232, 0.15);
-            border: 2px solid #FB5DE8;
+            background-color: rgba(42, 61, 228, 0.15);
+            border: 1px solid #2a3ce4;
             height: 100%;
             left: 0;
             position: absolute;
@@ -26,8 +26,8 @@ function injectStyles() {
             z-index: 10;
         }
         .detective-wapuu-overlay__tab {
-            background-color: #FB5DE8;
-            color: #000;
+            background-color: #2a3ce4;
+            color: #fff;
             font-size: 11px;
             height: 22px;
             left: -1px;

--- a/content.js
+++ b/content.js
@@ -30,7 +30,7 @@ function injectStyles() {
             color: #000;
             font-size: 11px;
             height: 22px;
-            left: -2px;
+            left: -1px;
             line-height: 22px;
             padding: 0px 8px;
             position: absolute;

--- a/content.js
+++ b/content.js
@@ -16,18 +16,25 @@ function injectStyles() {
             position: relative;
         }
         .detective-wapuu-overlay {
+            background-color: rgba(251, 93, 232, 0.15);
+            border: 2px solid #FB5DE8;
+            height: 100%;
+            left: 0;
             position: absolute;
             top: 0;
-            left: 0;
-            color: #fff;
-            background: rgba(251, 93, 232, 0.15);
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            height: 100%;
             width: 100%;
             z-index: 10;
-            border: 2px solid #FB5DE8;
+        }
+        .detective-wapuu-overlay__tab {
+            background-color: #FB5DE8;
+            color: #000;
+            font-size: 11px;
+            height: 22px;
+            left: -2px;
+            line-height: 22px;
+            padding: 0px 8px;
+            position: absolute;
+            top: -22px;
         }
     `;
 
@@ -40,8 +47,13 @@ function injectStyles() {
 
 function injectOverlay( name, block ) {
     const overlay = document.createElement('div');
+    const tab = document.createElement('span');
+
     overlay.classList.add('detective-wapuu-overlay');
-    overlay.innerText = name;
+    tab.classList.add('detective-wapuu-overlay__tab');
+
+    overlay.appendChild(tab);
+    tab.innerText = name;
 
     block.classList.add('is-detected');
     block.appendChild(overlay);

--- a/content.js
+++ b/content.js
@@ -3,7 +3,7 @@ const REGEX = /(?<=wp-block-).[^_\s]*/g;
 const IGNORED_BLOCKS = [ 'columns', 'column', 'group', 'coblocks-row', 'coblocks-column' ];
 
 function hasOverlay( block ) {
-    return block.classList.contains('has-detected') || block.parentNode.classList.contains('has-detected');
+    return block.classList.contains('is-detected') || block.parentNode.classList.contains('is-detected');
 }
 
 function injectStyles() {
@@ -12,7 +12,7 @@ function injectStyles() {
     }
 
     const styles = `
-        .has-detected {
+        .is-detected {
             position: relative;
         }
         .detective-wapuu-overlay {
@@ -42,7 +42,7 @@ function injectOverlay( name, block ) {
     overlay.classList.add('detective-wapuu-overlay');
     overlay.innerText = name;
 
-    block.classList.add('has-detected');
+    block.classList.add('is-detected');
     block.appendChild(overlay);
 }
 

--- a/content.js
+++ b/content.js
@@ -20,13 +20,14 @@ function injectStyles() {
             top: 0;
             left: 0;
             color: #fff;
-            background: rgba(0, 0, 0, 0.6);
+            background: rgba(251, 93, 232, 0.15);
             display: flex;
             align-items: center;
             justify-content: center;
             height: 100%;
             width: 100%;
             z-index: 10;
+            border: 2px solid #FB5DE8;
         }
     `;
 


### PR DESCRIPTION
This PR changes the block indicators from:

<img width="1255" alt="Screen Shot 2020-03-10 at 11 07 32 AM" src="https://user-images.githubusercontent.com/1813435/76326665-60c4b080-62bf-11ea-8188-563d68ce19ec.png">

to:

<img width="1256" alt="Screen Shot 2020-03-10 at 11 07 10 AM" src="https://user-images.githubusercontent.com/1813435/76326625-4e4a7700-62bf-11ea-9c76-034f331a51b8.png">

